### PR TITLE
Change required property in update status dialog

### DIFF
--- a/podium-gateway/src/main/webapp/app/shared/status-update/request-update-dialog.component.html
+++ b/podium-gateway/src/main/webapp/app/shared/status-update/request-update-dialog.component.html
@@ -29,7 +29,7 @@
                        jhiTranslate="request.statusupdate.form.summary.label">Summary</label>
 
                 <input type="text" class="form-control" name="messageSummary" id="messageSummary"
-                       [required]="statusUpdateAction" minlength="1" maxlength="50" #messageSummary="ngModel"
+                       [required]="statusUpdateActionExists" minlength="1" maxlength="50" #messageSummary="ngModel"
                        autocomplete="off" placeholder="{{'request.statusupdate.form.summary.placeholder' | translate}}"
                        [(ngModel)]="message.summary"/>
             </div>

--- a/podium-gateway/src/main/webapp/app/shared/status-update/request-update-dialog.component.html
+++ b/podium-gateway/src/main/webapp/app/shared/status-update/request-update-dialog.component.html
@@ -29,7 +29,7 @@
                        jhiTranslate="request.statusupdate.form.summary.label">Summary</label>
 
                 <input type="text" class="form-control" name="messageSummary" id="messageSummary"
-                       required minlength="1" maxlength="50" #messageSummary="ngModel"
+                       [required]="statusUpdateAction" minlength="1" maxlength="50" #messageSummary="ngModel"
                        autocomplete="off" placeholder="{{'request.statusupdate.form.summary.placeholder' | translate}}"
                        [(ngModel)]="message.summary"/>
             </div>

--- a/podium-gateway/src/main/webapp/app/shared/status-update/request-update-status-dialog.component.ts
+++ b/podium-gateway/src/main/webapp/app/shared/status-update/request-update-status-dialog.component.ts
@@ -45,6 +45,14 @@ export class RequestUpdateStatusDialogComponent extends RequestUpdateDialogCompo
     }
 
     /**
+     * Check if status update action is set or not.
+     * @returns true if exists, false if doesn't.
+     */
+    statusUpdateActionExists(): boolean {
+        return !!this.statusUpdateAction;
+    }
+
+    /**
      * Confirm and submit a status update with a message
      * returns an unsubscribed observable with the action
      */


### PR DESCRIPTION
Make summary field mandatory in request update dialog only when updating request status (PODIUM-107).