### PR TITLE
Fix for review feedback refresh on request update

### DIFF
--- a/podium-gateway/src/main/webapp/app/shared/request/request-review-panel/request-review-panel.component.ts
+++ b/podium-gateway/src/main/webapp/app/shared/request/request-review-panel/request-review-panel.component.ts
@@ -43,7 +43,7 @@ export class RequestReviewPanelComponent implements OnInit, OnDestroy {
     ) {
         this.requestSubscription = this.requestService.onRequestUpdate.subscribe((request: RequestBase) => {
             this.request = request;
-            this.lastReviewFeedback = this.requestService.getLastReviewFeedbacks(this.request.reviewRounds);
+            this.setRequestReviewFeedback();
         });
     }
 
@@ -55,6 +55,16 @@ export class RequestReviewPanelComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
+        this.setRequestReviewFeedback();
+    }
+
+    ngOnDestroy() {
+        if (this.requestSubscription) {
+            this.requestSubscription.unsubscribe();
+        }
+    }
+
+    setRequestReviewFeedback() {
         if (this.request.reviewRounds.length) {
             if (this.requestAccessService.isReviewerFor(this.request)) {
                 this.principal.identity().then((account) => {
@@ -65,12 +75,6 @@ export class RequestReviewPanelComponent implements OnInit, OnDestroy {
             } else {
                 this.lastReviewFeedback = this.requestService.getLastReviewFeedbacks(this.request.reviewRounds);
             }
-        }
-    }
-
-    ngOnDestroy() {
-        if (this.requestSubscription) {
-            this.requestSubscription.unsubscribe();
         }
     }
 }


### PR DESCRIPTION
Correctly parse review feedback when the request is updated for a user instead of fetching all reviews.