### PR TITLE
Improve token checks.

### DIFF
--- a/podium-uaa/src/main/java/nl/thehyve/podium/domain/User.java
+++ b/podium-uaa/src/main/java/nl/thehyve/podium/domain/User.java
@@ -121,7 +121,7 @@ public class User extends AbstractAuditingEntity implements AuthenticatedUser, U
 
     @Size(min = 2, max = 5)
     @Column(name = "lang_key", length = 5)
-    private String langKey;
+    private String langKey = "en";
 
     @Size(max = 20)
     @Column(name = "activation_key", length = 20)

--- a/podium-uaa/src/test/java/nl/thehyve/podium/security/SecurityServiceUnitTest.java
+++ b/podium-uaa/src/test/java/nl/thehyve/podium/security/SecurityServiceUnitTest.java
@@ -33,7 +33,9 @@ public class SecurityServiceUnitTest {
     @Test
     public void testgetCurrentUserLogin() {
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken("admin", "admin"));
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(AuthorityConstants.BBMRI_ADMIN));
+        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken("admin", "admin", authorities));
         SecurityContextHolder.setContext(securityContext);
         String login = SecurityService.getCurrentUserLogin();
         assertThat(login).isEqualTo("admin");
@@ -57,7 +59,10 @@ public class SecurityServiceUnitTest {
     @Test
     public void testIsAuthenticated() {
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken("admin", "admin"));
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(AuthorityConstants.BBMRI_ADMIN));
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken("admin", "admin", authorities);
+        securityContext.setAuthentication(token);
         SecurityContextHolder.setContext(securityContext);
         boolean isAuthenticated = SecurityService.isAuthenticated();
         assertThat(isAuthenticated).isTrue();


### PR DESCRIPTION
Make the access token checks more strict. The authenticated bit needs to be set, and it should not be a client only token (some OAuth2 clients may be served access without user credentials, but such tokens are not what we mean with `isAuthenticated()`).