### PR TITLE
initialize set to empty set. not null

### DIFF
--- a/podium-gateway/src/main/java/nl/thehyve/podium/domain/RequestDetail.java
+++ b/podium-gateway/src/main/java/nl/thehyve/podium/domain/RequestDetail.java
@@ -19,6 +19,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -81,7 +82,7 @@ public class RequestDetail implements Serializable {
     )
     @Fetch(FetchMode.JOIN)
     @BatchSize(size = 1000)
-    private Set<RequestType> requestType;
+    private Set<RequestType> requestType = new HashSet<>();
 
     @Column(name = "combined_request")
     private Boolean combinedRequest;


### PR DESCRIPTION
fix for PODIUM-276
returning null instead of an empty set breaks the front end. Please check if this is the way we want to fix it.
