### PR TITLE
Fix password validation and confirmation in password form.

### DIFF
--- a/podium-gateway/src/main/webapp/app/account/password/password.component.html
+++ b/podium-gateway/src/main/webapp/app/account/password/password.component.html
@@ -34,19 +34,20 @@
                     <input type="password" class="form-control" id="password"
                         name="password" #passwordInput="ngModel"
                         placeholder="{{'global.form.newpassword.placeholder' | translate}}"
-                        [(ngModel)]="password" minlength=8 maxlength=1000 required>
+                        [(ngModel)]="password" minlength=8 maxlength=1000 required
+                           pdmPasswordValidator="password">
                     <div *ngIf="passwordInput.dirty && passwordInput.invalid">
                         <small class="form-text text-danger"
                            *ngIf="passwordInput.errors.required"
                            [translate]="'global.messages.validate.newpassword.required'">
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordInput.errors.minlength"
-                           [translate]="'global.messages.validate.newpassword.minlength'">
-                        </small>
-                        <small class="form-text text-danger"
                            *ngIf="passwordInput.errors.maxlength"
                            [translate]="'global.messages.validate.newpassword.maxlength'">
+                        </small>
+                        <small class="form-text text-danger"
+                               *ngIf="passwordInput.errors.passwordValidator"
+                               [translate]="'global.messages.validate.newpassword.requirements'">
                         </small>
                     </div>
                     <pdm-password-strength-bar [passwordToCheck]="password"></pdm-password-strength-bar>
@@ -58,14 +59,14 @@
                     <input type="password" class="form-control" id="confirmPassword"
                         name="confirmPassword" #confirmPasswordInput="ngModel"
                         placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
-                        [(ngModel)]="confirmPassword" required [pdmPasswordMatches]="password">
+                        [(ngModel)]="confirmPassword" required [pdmPasswordMatches]="passwordInput">
                     <div *ngIf="confirmPasswordInput.dirty && confirmPasswordInput.invalid">
                         <small class="form-text text-danger"
                             *ngIf="confirmPasswordInput.errors.required"
                             [translate]="'global.messages.validate.confirmpassword.required'">
                         </small>
                         <small class="form-text text-danger"
-                            *ngIf="confirmPasswordInput.errors.passwordMatches"
+                            *ngIf="confirmPasswordInput.errors.pdmPasswordMatches"
                             [translate]="'global.messages.validate.confirmpassword.shouldMatch'">
                         </small>
                     </div>

--- a/podium-gateway/src/main/webapp/app/shared/validators/password-validator.directive.ts
+++ b/podium-gateway/src/main/webapp/app/shared/validators/password-validator.directive.ts
@@ -17,8 +17,8 @@ function validatePasswordFactory(): ValidatorFn {
 
         // (                        # Start of group
         //  (?=.*\d)                # must contains one digit from 0-9
-        //  (?=.*[@A-Za-z])         # must contains one lowercase characters
-        //  (?=.*[^a-zA-Z0-9 ])     # must contains one special symbols in the list "@#$%"
+        //  (?=.*[@A-Za-z])         # must contains one alphabetical character
+        //  (?=.*[^a-zA-Z0-9 ])     # must contains one special symbol
         //  .                       # match anything with previous condition checking
         //  {8}                     # length at least 8 characters
         // )                        # End of group

--- a/podium-gateway/src/main/webapp/i18n/en/global.json
+++ b/podium-gateway/src/main/webapp/i18n/en/global.json
@@ -108,6 +108,7 @@
                     "required": "Your password is required.",
                     "minlength": "Your password is required to be at least 8 characters.",
                     "maxlength": "Your password cannot be longer than 1000 characters.",
+                    "requirements": "Your password must be at least 8 characters length, containing alphanumeric and non-alphanumeric characters.",
                     "strength": "Password strength:"
                 },
                 "confirmpassword": {


### PR DESCRIPTION
This fixes password validation and confirmation for the password form. However, this one was already broken before (e.g., on the current acceptance environment.
But the same functionality needs to be restored in the registration form, where it was working before:
- in-place validation of min and max length, character requirements with clear feedback: `Your password must be at least 8 characters length, containing alphanumeric and non-alphanumeric characters.`
- in-place validation of password confirmation