### PR TITLE
Registration form password fixes

### DIFF
--- a/podium-gateway/src/main/webapp/app/account/register/register.component.html
+++ b/podium-gateway/src/main/webapp/app/account/register/register.component.html
@@ -189,7 +189,7 @@
                 <!--Institute-->
                 <div class="form-group">
                     <label  class="form-control-label" for="institute" >Institute</label>
-                    <input 
+                    <input
                         type="text"
                         class="form-control"
                         id="institute"
@@ -217,7 +217,7 @@
                 <!--Department-->
                 <div class="form-group">
                     <label  class="form-control-label" for="department" >Department</label>
-                    <input 
+                    <input
                         type="text"
                         class="form-control"
                         id="department"
@@ -246,7 +246,7 @@
                 <!--Function (Job Title)-->
                 <div class="form-group">
                     <label  class="form-control-label" for="jobTitle" >Function</label>
-                    <input 
+                    <input
                         type="text"
                         class="form-control"
                         id="jobTitle"
@@ -280,7 +280,7 @@
                 </div>
 
                 <br>
-                <h3>Create Password</h3>
+                <h3>Create password</h3>
 
                 <!--Password-->
                 <div class="form-group">
@@ -296,8 +296,8 @@
                         *ngIf="registerForm.get('password')!.invalid && (registerForm.get('password')!.dirty || registerForm.get('password')!.touched)"
                     >
                         <small class="form-text text-danger"
-                            *ngIf="registerForm.get('password')?.errors?.required"
-                            [translate]="'global.messages.validate.newpassword.required'">
+                            *ngIf="registerForm.get('password')?.errors?.maxlength"
+                            [translate]="'global.messages.validate.newpassword.maxlength'">
                         </small>
 
                         <small class="form-text text-danger"

--- a/podium-gateway/src/main/webapp/app/account/register/register.component.html
+++ b/podium-gateway/src/main/webapp/app/account/register/register.component.html
@@ -139,12 +139,8 @@
                             [translate]="'global.messages.validate.email.required'">
                         </small>
                         <small class="form-text text-danger"
-                            *ngIf="registerForm.get('email')?.errors?.email"
+                            *ngIf="registerForm.get('email')?.errors?.email || registerForm.get('email')?.errors?.minlength"
                             [translate]="'global.messages.validate.email.invalid'">
-                        </small>
-                        <small class="form-text text-danger"
-                            *ngIf="registerForm.get('email')?.errors?.minlength"
-                            [translate]="'global.messages.validate.email.minlength'">
                         </small>
                         <small class="form-text text-danger"
                             *ngIf="registerForm.get('email')?.errors?.maxlength"


### PR DESCRIPTION
- Remove redundant feedback on password validation, add max length message.
  The 'required' and 'passwordValidator' checks overlap, but the max length reqiurement is not covered by another one, but is relevant.
- Simplify feedback on invalid email address in registration form.

I think this is the last change set from my side. After this, I thing the fixes can be merged into dev and we can deploy a new snapshot on podium-test.
