### PR TITLE
Prevent submitting a revision when attachment types are not set.

### DIFF
--- a/podium-gateway/src/main/webapp/app/shared/request/action-bars/request-action-toolbar/request-action-toolbar.component.html
+++ b/podium-gateway/src/main/webapp/app/shared/request/action-bars/request-action-toolbar/request-action-toolbar.component.html
@@ -21,7 +21,7 @@
                         <span [translate]="'request.toolbar.saveDraft'"></span>
                     </button>
                     <button type="submit" class="btn btn-success" id="submit-draft-btn"
-                            [disabled]="!canSubmitDraft()" (click)="submitDraft()">
+                            [disabled]="!canSubmit()" (click)="submitDraft()">
                         <span [translate]="'request.toolbar.submit'"></span>
                     </button>
                 </div>
@@ -58,7 +58,7 @@
                                 <span [translate]="'request.toolbar.save'"></span>
                             </button>
                             <button type="submit" class="btn btn-success" id="submit-request-btn"
-                                    [disabled]="!form.form.valid" (click)="submitRequest()">
+                                    [disabled]="!canSubmit()" (click)="submitRequest()">
                                 <span [translate]="'request.toolbar.saveAndSubmit'"></span>
                             </button>
                         </div>

--- a/podium-gateway/src/main/webapp/app/shared/request/action-bars/request-action-toolbar/request-action-toolbar.component.ts
+++ b/podium-gateway/src/main/webapp/app/shared/request/action-bars/request-action-toolbar/request-action-toolbar.component.ts
@@ -118,7 +118,7 @@ export class RequestActionToolbarComponent implements OnInit, OnDestroy {
         return this.checks.validation && this.request.hasAttachmentsTypes;
     }
 
-    canSubmitDraft() {
+    canSubmit() {
         return this.form.form.valid && this.request.hasAttachmentsTypes;
     }
 


### PR DESCRIPTION
Another small bug. When a requester is asked to revise a request, the requester can upload an attachment without specifying an attachment type. This will result in errors later (e.g., during validation: the validate button for the coordinator will remain disabled).

This change fixes it for the front end, but I think the same validation should be added to the back end. Although the actual problem (disabled validate button) only occurs in the front end, so may be a front end measure is sufficient in this case.
What do you think?