### PR TITLE
Exclude Deleted Users from Role Mapping

### DIFF
--- a/podium-uaa/src/main/java/nl/thehyve/podium/service/mapper/RoleMapper.java
+++ b/podium-uaa/src/main/java/nl/thehyve/podium/service/mapper/RoleMapper.java
@@ -36,7 +36,9 @@ public interface RoleMapper {
     List<RoleRepresentation> rolesToRoleDTOs(List<Role> role);
 
     default Set<UUID> uuidsFromUsers (Set<User> users) {
-        return users.stream().map(User::getUuid)
+        return users.stream()
+            .filter(u -> !u.isDeleted())
+            .map(User::getUuid)
             .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
When you delete a user who still has any roles in an organisation, the organisation's permissions view breaks since the user can no longer be found, causing an exception.

This fix excludes "obsolete" user UUIDs from the organisation roles response.