### PR TITLE
Fix the feedback on login errors.

### DIFF
--- a/podium-gateway/src/main/webapp/app/login/login.component.ts
+++ b/podium-gateway/src/main/webapp/app/login/login.component.ts
@@ -81,8 +81,8 @@ export class PodiumLoginComponent implements OnInit, AfterViewInit {
                 this.userAccountLocked = false;
                 this.emailNotVerified = false;
                 this.accountNotVerified = false;
-                if (err && err._body) {
-                    let response =  JSON.parse(err._body);
+                if (err && err.error) {
+                    let response = err.error;
                     switch (response.error_description) {
                         case 'The user account is locked.':
                             this.userAccountLocked = true;


### PR DESCRIPTION
In case of locked or unverified accounts, an appropriate message should be displayed.
This fixes an error that the error type was not correctly parsed from the server response.

Fixes [PODIUM-299](https://thehyve.atlassian.net/browse/PODIUM-299).