### PR TITLE
Password Reset Page is not stored for Redirection

### DIFF
--- a/podium-gateway/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts
+++ b/podium-gateway/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts
@@ -16,7 +16,8 @@ export const passwordResetFinishRoute: Route = {
   component: PasswordResetFinishComponent,
   data: {
     authorities: [],
-    pageTitle: 'global.menu.account.password'
+    pageTitle: 'global.menu.account.password',
+    rememberPage: false,
   },
   canActivate: [UserRouteAccessService]
 };

--- a/podium-gateway/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts
+++ b/podium-gateway/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts
@@ -17,7 +17,7 @@ export const passwordResetFinishRoute: Route = {
   data: {
     authorities: [],
     pageTitle: 'global.menu.account.password',
-    rememberPage: false,
+    rememberPage: false
   },
   canActivate: [UserRouteAccessService]
 };

--- a/podium-gateway/src/main/webapp/app/account/password-reset/init/password-reset-init.route.ts
+++ b/podium-gateway/src/main/webapp/app/account/password-reset/init/password-reset-init.route.ts
@@ -16,7 +16,8 @@ export const passwordResetInitRoute: Route = {
   component: PasswordResetInitComponent,
   data: {
     authorities: [],
-    pageTitle: 'global.menu.account.password'
+    pageTitle: 'global.menu.account.password',
+    rememberPage: false
   },
   canActivate: [UserRouteAccessService]
 };

--- a/podium-gateway/src/main/webapp/app/account/register/register.route.ts
+++ b/podium-gateway/src/main/webapp/app/account/register/register.route.ts
@@ -16,7 +16,8 @@ export const registerRoute: Route = {
   component: RegisterComponent,
   data: {
     authorities: [],
-    pageTitle: 'register.title'
+    pageTitle: 'register.title',
+    rememberPage: false
   },
   canActivate: [UserRouteAccessService]
 };

--- a/podium-gateway/src/main/webapp/app/account/verify/verify.route.ts
+++ b/podium-gateway/src/main/webapp/app/account/verify/verify.route.ts
@@ -16,7 +16,8 @@ export const verifyRoute: Route = {
   component: VerifyComponent,
   data: {
     authorities: [],
-    pageTitle: 'verify.title'
+    pageTitle: 'verify.title',
+    rememberPage: false
   },
   canActivate: [UserRouteAccessService]
 };

--- a/podium-gateway/src/main/webapp/app/core/auth/user-route-access.service.ts
+++ b/podium-gateway/src/main/webapp/app/core/auth/user-route-access.service.ts
@@ -29,7 +29,9 @@ export class UserRouteAccessService implements CanActivate {
                 const authorities = route.data['authorities'];
 
                 if (!authorities || authorities.length === 0 || this.accountService.hasAnyAuthority(authorities)) {
-                    this.stateStorageService.storeUrl(state.url);
+                    if (route.data['rememberPage'] !== false) {
+                        this.stateStorageService.storeUrl(state.url);
+                    }
                     return true;
                 }
 
@@ -41,7 +43,9 @@ export class UserRouteAccessService implements CanActivate {
                     return false;
                 }
 
-                this.stateStorageService.storeUrl(state.url);
+                if (route.data['rememberPage'] !== false) {
+                    this.stateStorageService.storeUrl(state.url);
+                }
                 this.router.navigate(['/']);
                 return false;
             })


### PR DESCRIPTION
With this fix a user is redirected to the default page after password reset and sign-in.

Alternatively, we can check on the password reset page if a user is already logged-in and redirect to the default page.