### PR TITLE
Permission Checks on Organisation Form fixed

### DIFF
--- a/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.html
+++ b/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.html
@@ -84,12 +84,6 @@
                                 <input type="checkbox"
                                     [(ngModel)]="organisation.activated" name="organisation_active"
                                     [disabled]="!canActivateOrganisation" />
-
-                                <div *ngIf="!canActivateOrganisation && !organisation.activated">
-                                    <small class="form-text text-danger"
-                                        [innerHTML]="'organisation.organisationAdminInactive' | translate">
-                                    </small>
-                                </div>
                             </div>
 
                             <div class="action-footer-container">

--- a/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.html
+++ b/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.html
@@ -83,11 +83,11 @@
                                 </label>
                                 <input type="checkbox"
                                     [(ngModel)]="organisation.activated" name="organisation_active"
-                                    [disabled]="isOrganisationAdmin(currentAccount)" />
+                                    [disabled]="!canActivateOrganisation" />
 
-                                <div *ngIf="isOrganisationAdmin(currentAccount) && !organisation.activated">
+                                <div *ngIf="!canActivateOrganisation && !organisation.activated">
                                     <small class="form-text text-danger"
-                                           [translate]="'organisation.organisationAdminInactive'">
+                                        [innerHTML]="'organisation.organisationAdminInactive' | translate">
                                     </small>
                                 </div>
                             </div>

--- a/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.ts
+++ b/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.ts
@@ -115,6 +115,6 @@ export class OrganisationFormComponent implements OnInit {
 
     get canActivateOrganisation() {
         let authorities = this.currentAccount?.authorities || [];
-        return authorities.includes('ROLE_PODIUM_ADMIN') || authorities.includes('ROLE_BBMRI_ADMIN');
+        return authorities.includes('ROLE_BBMRI_ADMIN');
     }
 }

--- a/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.ts
+++ b/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation-form/organisation-form.component.ts
@@ -113,9 +113,8 @@ export class OrganisationFormComponent implements OnInit {
         }
     }
 
-    isOrganisationAdmin (currentUser: User) {
-        if (currentUser) {
-            return currentUser.authorities.indexOf('ROLE_ORGANISATION_ADMIN') > -1;
-        }
+    get canActivateOrganisation() {
+        let authorities = this.currentAccount?.authorities || [];
+        return authorities.includes('ROLE_PODIUM_ADMIN') || authorities.includes('ROLE_BBMRI_ADMIN');
     }
 }

--- a/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation.component.html
+++ b/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation.component.html
@@ -12,7 +12,7 @@
     <h2>
         <span [translate]="'organisation.home.title'"></span>
         <button class="btn btn-primary float-right create-organisation"
-                *pdmHasAnyAuthority="['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN']"
+                *pdmHasAnyAuthority="['ROLE_BBMRI_ADMIN']"
                 [routerLink]="['./new']">
             <span class="material-icons">add_circle_outline</span>
             <span class="d-none d-md-inline-flex"
@@ -60,7 +60,7 @@
                             </span>
                         </button>
                         <button type="button" class="btn btn-sm test-activation-btn"
-                                *pdmHasAnyAuthority="['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN']"
+                                *pdmHasAnyAuthority="['ROLE_BBMRI_ADMIN']"
                                 [ngClass]="{'btn-warning': !organisation.activated, 'btn-success': organisation.activated}"
                                 (click)="toggleActivated (organisation)">
                             <i *ngIf="!organisation.activated" class="material-icons">pause_circle_filled</i>
@@ -75,7 +75,7 @@
                             </span>
                         </button>
                         <button type="submit"
-                                *pdmHasAnyAuthority="['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN']"
+                                *pdmHasAnyAuthority="['ROLE_BBMRI_ADMIN']"
                                 [routerLink]="['./', { outlets: { popup: 'detail/'+ organisation.uuid + '/delete'} }]"
                                 class="btn btn-danger btn-sm test-delete-btn">
                             <span class="material-icons">remove_circle_outline</span>

--- a/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation.route.ts
+++ b/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation.route.ts
@@ -40,7 +40,7 @@ export const organisationRoute: Routes = [
             'pagingParams': OrganisationResolvePagingParams
         },
         data: {
-            authorities: ['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN', 'ROLE_ORGANISATION_ADMIN'],
+            authorities: ['ROLE_BBMRI_ADMIN', 'ROLE_ORGANISATION_ADMIN'],
             pageTitle: 'organisation.home.title',
             breadcrumb: 'overview'
         },
@@ -50,7 +50,7 @@ export const organisationRoute: Routes = [
         path: 'new',
         component: OrganisationFormComponent,
         data: {
-            authorities: ['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN'],
+            authorities: ['ROLE_BBMRI_ADMIN'],
             pageTitle: 'organisation.detail.title',
             breadcrumb: 'new organisation'
         },
@@ -60,7 +60,7 @@ export const organisationRoute: Routes = [
         path: 'detail/:uuid/delete',
         component: OrganisationDeletePopupComponent,
         data: {
-            authorities: ['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN'],
+            authorities: ['ROLE_BBMRI_ADMIN'],
             pageTitle: 'organisation.home.title'
         },
         outlet: 'popup',
@@ -70,7 +70,7 @@ export const organisationRoute: Routes = [
         path: 'edit/:uuid',
         component: OrganisationFormComponent,
         data: {
-            authorities: ['ROLE_PODIUM_ADMIN', 'ROLE_BBMRI_ADMIN', 'ROLE_ORGANISATION_ADMIN'],
+            authorities: ['ROLE_BBMRI_ADMIN', 'ROLE_ORGANISATION_ADMIN'],
             pageTitle: 'organisation.detail.title',
             breadcrumb: 'edit organisation'
         },

--- a/podium-gateway/src/main/webapp/i18n/en/organisation.json
+++ b/podium-gateway/src/main/webapp/i18n/en/organisation.json
@@ -16,8 +16,6 @@
         "shortName": "Short name",
         "activated": "Activated",
         "deactivated": "Deactivated",
-        "organisationAdminInactive":
-            "Your organisation requires all fields to be filled in and has a user assigned for each of the roles.<br />Contact the BBMRI admin to validate your organisation.",
         "saved": "Successfully saved organisation",
         "updated": "Successfully updated organisation",
         "created": "A new organisation is created with identifier {{ param }}",


### PR DESCRIPTION
cf. https://github.com/thehyve/podium/blob/dev/podium-gateway/src/main/webapp/app/backoffice/modules/organisation/organisation.component.html#L63

To reproduce the original bug: login as an admin, go to the organisation management page, assign yourself as an organisation admin; logout/login, try to create a new org — see the "Acitvated" checkbox grayed out and error message shown.

https://thehyve.atlassian.net/browse/PODIUM-305