### PR TITLE
Auth Token not injected for Public URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.6]
+- Requests to public endpoints no longer send the Authorization header;
+- Login issue fixed (an expired/invalid auth token no longer breaks the app);
+
 ## [1.0.5]
 - Unnecessary error message removed from the Organization Form view;
 - Podium Admin no longer can access organization management pages;


### PR DESCRIPTION
Fixes https://thehyve.atlassian.net/browse/PODIUM-306

Before: if a client, for any reason, stored an invalid auth token, it was sent along with every request including password reset/login/resource fetching attempts. Since the token is not valid, server rejected login attempts, making signing in impossible for the client.

After: the web app no longer sends the auth token for the URLs that do not require it. No token = no rejection on public endpoints.

A note on an alternative solution: currently, the app is configured so that the token, when present, is _always_ processed, even for the public URLs. It is possible to alter this behaviour, completely bypassing auth checks for public endpoints, but this approach is not totally trivial (i.e. I'll have to add an extra WebSecurityConf class) and requires more configuration changes than I'm comfortable with for this fix + a client is not supposed to send an unnecessary auth data to public endpoints.